### PR TITLE
missed the renaming in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ doc/*
 *.elf
 *.asm
 *.d
-Qemu-sifive_e-FreedomStudio/build/main_fett.map
+Qemu-sifive_e-FreedomStudio/build/main_besspin.map


### PR DESCRIPTION
The script was ignoring the files that have `.git` in them to avoid messing with `.gitmodules` and all the files in `.git/` directories. So it missed this one.